### PR TITLE
Fix MapView z-index to prevent overlay issues

### DIFF
--- a/client/components/MapView.tsx
+++ b/client/components/MapView.tsx
@@ -105,7 +105,7 @@ export default function MapView({
   }
 
   return (
-    <div className={`relative w-full h-full ${className}`}>
+    <div className={`relative w-full h-full z-10 ${className}`}>
       <MapContainer
         center={[userLocation.lat, userLocation.lng]}
         zoom={13}


### PR DESCRIPTION
## Purpose
Fix MapView component overlaying category filters and navigation header when users scroll down the page by adjusting the component's z-index positioning.

## Code changes
- Added `z-10` class to the MapView container div to set appropriate z-index stacking order
- Prevents the map component from appearing above other UI elements during page scrollTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6b495f8d4532493ca59c24748debd8e6/pixel-zone)

👀 [Preview Link](https://6b495f8d4532493ca59c24748debd8e6-pixel-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6b495f8d4532493ca59c24748debd8e6</projectId>-->
<!--<branchName>pixel-zone</branchName>-->