### PR TITLE
Fix MapView z-index to prevent overlay issues

### DIFF
--- a/client/components/RestaurantView.tsx
+++ b/client/components/RestaurantView.tsx
@@ -114,7 +114,7 @@ export default function RestaurantView({
 
       {/* Content */}
       {viewMode === "map" ? (
-        <div className="h-96 rounded-lg overflow-hidden border">
+        <div className="h-96 rounded-lg overflow-hidden border relative z-[200]">
           <MapView
             restaurants={availableRestaurants}
             onRestaurantSelect={handleRestaurantSelect}


### PR DESCRIPTION
## Purpose
Fix MapView component overlaying category filters and navigation header when users scroll down the page. This ensures proper layering of UI elements and maintains usability of navigation controls.

## Code changes
- Added `relative z-[200]` classes to the MapView container div in RestaurantView.tsx
- Increased z-index value to ensure the map renders below other UI elements like filters and navigationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6b495f8d4532493ca59c24748debd8e6/zenith-sanctuary)

👀 [Preview Link](https://6b495f8d4532493ca59c24748debd8e6-zenith-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6b495f8d4532493ca59c24748debd8e6</projectId>-->
<!--<branchName>zenith-sanctuary</branchName>-->